### PR TITLE
Update Package to handle AbstractTrees v0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractTrees = "0.3.4"
+AbstractTrees = ["0.3.4", "0.4"]
 RecipesBase = "1.1.1"
 julia = "^1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractTrees = ["0.3.4", "0.4"]
+AbstractTrees = "0.4"
 RecipesBase = "1.1.1"
 julia = "^1.4"

--- a/src/node.jl
+++ b/src/node.jl
@@ -128,6 +128,10 @@ Base.show(io::IO, n::Node) = write(io,"Node($(id(n)), $(n.data))")
 
 # AbstractTrees interface
 AbstractTrees.children(n::Node) = isdefined(n, :children) ? n.children : typeof(n)[]
+AbstractTrees.nodevalue(n::Node) = n
+AbstractTrees.parent(n::Node) = parent(n)
+AbstractTrees.ParentLinks(::Type{<:Node}) = AbstractTrees.StoredParents()
+AbstractTrees.ChildIndexing(::Type{<:Node}) = AbstractTrees.IndexedChildren()
 Base.eltype(::Type{<:TreeIterator{Node{I,T}}}) where {I,T} = Node{I,T}
 AbstractTrees.nodetype(::Type{Node{I,T}}) where {I,T} = Node{I,T}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,10 +25,10 @@ using NewickTree, AbstractTrees
     @testset "AbstractTrees interface" begin
         n = readnw(readline(joinpath(@__DIR__, "ncov-spike.nw")))
         @test Set(collect(Leaves(n))) == Set(getleaves(n))
-        t = Tree(n)
-        @test t[2][1] == n[2][1]
-        collect(PostOrderDFS(t)) .== postwalk(n)
-        collect(PreOrderDFS(t)) .== prewalk(n)
+        # t = Tree(n) # doesn't exist in AbstractTrees@0.4
+        # @test t[2][1] == n[2][1]
+        @test all(collect(PostOrderDFS(n)) .== postwalk(n))
+        @test all(collect(PreOrderDFS(n)) .== prewalk(n))
         # NOTE: the order doesn't have to be exactly the same, but
         # turns out it is.
     end


### PR DESCRIPTION
I ran into some compatibility issues with conflicting dependencies with NewickTree and other packages that have updated to AbstractTrees v0.4+. 

Main issue is just the compat heading in the project file which I've updated. I also added the basic Definitions and Traits for AbstractTrees to match the updated interface.

Thanks for working on this package! it's been a big help for my grad school work.