### PR TITLE
bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NewickTree"
 uuid = "b0a14db8-6308-4ebc-8917-f72cd81f5094"
 authors = ["arzwa <arzwa@psb.vib.ugent.be>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Thanks for merging my previous pull request, do you mind registering a new version? 

Even though the changes were merged to main, installing with `add NewickTree` still pulls the pre-abstracttrees v0.4 compatibility version which creates version conflicts with other packages.

This pull request just bumps the version of this package.