### PR TITLE
feat: implement conversion from Hclust to Node

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,24 @@
 name = "NewickTree"
 uuid = "b0a14db8-6308-4ebc-8917-f72cd81f5094"
-authors = ["arzwa <arzwa@psb.vib.ugent.be>"]
-version = "0.3.1"
+authors = ["arzwa <arzwa@psb.vib.ugent.be>", "Carlos Vigil-Vásquez <carlos.vigil.v@gmail.com>"]
+version = "0.4.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[weakdeps]
+Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
+
+[extensions]
+ClusteringExt = ["Clustering"]
+
+[targets]
+test = ["Clustering"]
+
 [compat]
 AbstractTrees = "0.4"
+Clustering = "0.15.8"
 RecipesBase = "1.1.1"
-julia = "^1.4"
+julia = "^1.9"

--- a/ext/ClusteringExt.jl
+++ b/ext/ClusteringExt.jl
@@ -1,0 +1,27 @@
+module ClusteringExt
+
+using NewickTree, Clustering
+using NewickTree: setdistance!
+
+function Base.convert(::Type{Node}, hc::Hclust)
+   nodes = [Node(i, n=string(n), d=0.) for (i,n) in zip(hc.order,hc.labels)]
+   n = length(nodes)
+   idfun(x) = x > 0 ? x + n : abs(x)
+   for i=1:size(hc.merges, 1)
+       nid = n + i
+       j, k = idfun.(hc.merges[i,:])
+       a = nodes[j]
+       b = nodes[k]
+       h = hc.heights[i]
+       newnode = Node(nid, n="$nid", d=h)
+       setdistance!(a, h-distance(a))
+       setdistance!(b, h-distance(b))
+       push!(newnode, a)
+       push!(newnode, b)
+       push!(nodes, newnode)
+   end
+   setdistance!(nodes[end], 0.)
+   return nodes[end]
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,22 @@ using NewickTree, AbstractTrees
         @test nwstr(t[1]) == "((1,2),3);"
         @test nwstr(t[2][1]) == "4;"
     end
+
+    if isdefined(Base, :get_extension)
+        try
+            using Clustering
+
+            A = [1 1 5 5; 1 1 5 5; 5 5 1 1; 5 5 1 1]
+            hc = hclust(A)
+
+            @testset "Converters to `Node`" begin
+                @test hasmethod(convert, (Type{NewickTree.Node},Clustering.Hclust))
+                @test nwstr(convert(Node, hclust(A))) == "((1:1.0,2:1.0):4.0,(3:1.0,4:1.0):4.0):0.0;"
+            end
+        catch
+            @warn "Clustering not available, skipping extension tests"
+        end
+    end
 end
 
 


### PR DESCRIPTION
This commit implements a `Base.convert` dispatch based on the following GitHub issue:

https://github.com/JuliaStats/Clustering.jl/issues/209#issuecomment-824097832

This is provided through a package extension, therefore in bumps the minimum required version of Julia to 1.9 and adds Clustering.jl as a weak dependency.