### PR TITLE
feat: expose support function

### DIFF
--- a/src/NewickTree.jl
+++ b/src/NewickTree.jl
@@ -6,7 +6,7 @@ export Node, NewickData
 export isroot, isleaf, postwalk, prewalk, children, sister
 export getroot, getlca, getleaves, nodefilter
 export insertnode!, print_tree, readnw, writenw, @nw_str
-export distance, name, id, nwstr, degree, getheights
+export distance, name, id, nwstr, degree, getheights, support
 export set_outgroup!, set_outgroup
 
 include("node.jl")

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -103,13 +103,13 @@ end
 
 function get_nodedata(io::IOBuffer, c, name="")
     # get everything up to the next comma or )
-    support, c = _readwhile!(io, c)
+    _support, c = _readwhile!(io, c)
     distance = ""
     if c == ':'
         c = read(io, Char)
         distance, c = _readwhile!(io, c)
     end
-    sv = nanparse(support)
+    sv = nanparse(_support)
     if typeof(sv) == String
         name = String(strip(sv))
         sv = NaN

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using NewickTree, AbstractTrees
         @test distance(n) === NaN
         @test distance(first(n)) == 1.
         @test name(last(n)) == "C"
+        @test support(first(n)) == 90
 
         n = readnw(readline(joinpath(@__DIR__, "ncov-spike.nw")))
         @test map(x->(name(x), distance(x)), getleaves(n))[3][2] == 0.182372964


### PR DESCRIPTION
The title says it all: both `distance` and `name` are exposed for use, but not `support` (unsure why, but it's useful to have it available for building analysis with this package). This PR exposes says accessor to the public API.